### PR TITLE
Fixed 'Talk format' heading

### DIFF
--- a/pyconcz_2017/templates/proposals/talks_about.html
+++ b/pyconcz_2017/templates/proposals/talks_about.html
@@ -128,8 +128,9 @@
     <li>Testing</li>
     <li>Internet of Things</li>
     <li>Android / Mobile Development</li>
-    <li>Talk Format</li>
   </ul>
+
+  <h2>Talk Format</h2>
 
   <p>
     The preferred length for talks is 30 minutes. We also accept extended


### PR DESCRIPTION
I think that 'Talk format' should be a heading of paragraph and not suggested talk topic.